### PR TITLE
Add murata lora sigfox

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,0 +1,7 @@
+# Disk91 IoT SDK - Examples
+The different examples are located in different GitHub projects. This way you can easily clone the project locally and get all the dependencies. this is not poluting the main SDK.
+
+## STM32 platform
+* Make a led blinking - https://github.com/disk91/stm32-s2lp-sigfox/releases/tag/STEP1
+* Communicate over Sigfox Network - https://github.com/disk91/stm32-s2lp-sigfox
+* Communicate over LoRaWan Network - https://github.com/disk91/itsdk-example-murata-lora

--- a/Inc/it_sdk/sched/scheduler.h
+++ b/Inc/it_sdk/sched/scheduler.h
@@ -42,12 +42,13 @@
 
 #define ITSDK_SCHED_ERROR			0xFF
 
+#define ITSDK_SCHED_MAX_PERIOD		0x00FFFFFF	// 24b is the max duration
 /**
  * schedule configuration
  */
 typedef struct s_sched {
 	uint64_t nextRun;			// Next run time in ms
-	uint16_t period;			// Period between 2 execution
+	uint32_t period:24;			// Period between 2 execution (24 bits)
 								// Mode as a bitfield for task configuration see ITSDK_SCHED_CONF_XXX
 	uint8_t  skip:1;			//    skip missed execution
 	uint8_t	 halt:1;			//    stop for next executions
@@ -59,7 +60,7 @@ typedef struct s_sched {
  * Functions
  */
 void itdt_sched_execute();
-uint8_t itdt_sched_registerSched(uint16_t periodMs,uint16_t mode, void (*f)(void));
+uint8_t itdt_sched_registerSched(uint32_t periodMs,uint16_t mode, void (*f)(void));
 void itdf_sched_haltSched(uint8_t schedId);
 void itdf_sched_runSched(uint8_t schedId);
 

--- a/Inc/it_sdk/time/timer.h
+++ b/Inc/it_sdk/time/timer.h
@@ -29,7 +29,8 @@
 
 #include <stdbool.h>
 
-#define ITSDK_STIMER_INFINITE	0xFFFFFFFF
+#define ITSDK_STIMER_INFINITE		0xFFFFFFFF
+#define ITSDK_STIMER_INFINITE_64	0xFFFFFFFFFFFFFFFF
 
 typedef enum {
 	TIMER_INIT_SUCCESS=0,
@@ -63,7 +64,7 @@ itsdk_timer_return_t itsdk_hwtimer_sync_run(
 typedef struct s_itsdk_stimer_slot {
 	bool			inUse;								// This structure is in use
 	bool 	 		allowLowPower;						// when true a deep sleep switch is authorized during time wait
-	uint32_t		timeoutMs;							// End of the timer value
+	uint64_t		timeoutMs;							// End of the timer value
 	void 			(*callback_func)(uint32_t value);	// Callback function
 	uint32_t		customValue;
 } itsdk_stimer_slot_t;

--- a/Src/it_sdk/sched/scheduler.c
+++ b/Src/it_sdk/sched/scheduler.c
@@ -42,8 +42,12 @@ uint8_t __sNum = 0;
  * associated function to call. The mode params defines the sheduler behavior
  * Returns the scedId on sucees or ITSDK_SCHED_ERROR on error.
  */
-uint8_t itdt_sched_registerSched(uint16_t periodMs,uint16_t mode, void (*f)(void)) {
+uint8_t itdt_sched_registerSched(uint32_t periodMs,uint16_t mode, void (*f)(void)) {
 
+	if ( periodMs > ITSDK_SCHED_MAX_PERIOD ) {
+		log_error("[Sched] Period exceed Max\r\n");
+		return ITSDK_SCHED_ERROR;
+	}
 	if ( __sNum < ITSDK_SHEDULER_TASKS ) {
 		__scheds[__sNum].func=f;
 		__scheds[__sNum].period=periodMs;
@@ -69,7 +73,7 @@ void itdt_sched_execute() {
 					_LOG_SCHED(("[sched] (%d) exec @%ld\r\n",i,t));
 					(*__scheds[i].func)();
 				}
-	 		    __scheds[i].nextRun += __scheds[i].period;
+	 		    __scheds[i].nextRun += (uint64_t)__scheds[i].period;
 			}
 		} while (!__scheds[i].skip && __scheds[i].nextRun <= t );
 		while (__scheds[i].skip &&__scheds[i].nextRun <= t) __scheds[i].nextRun += __scheds[i].period;

--- a/Src/it_sdk/time/timer.c
+++ b/Src/it_sdk/time/timer.c
@@ -110,7 +110,7 @@ itsdk_timer_return_t itsdk_stimer_register(
 		__stimer_slots[i].allowLowPower = ((allowLowPower==TIMER_ACCEPT_LOWPOWER)?true:false);
 		__stimer_slots[i].customValue = value;
 		__stimer_slots[i].callback_func = callback_func;
-		__stimer_slots[i].timeoutMs = itsdk_time_get_ms()+ms;
+		__stimer_slots[i].timeoutMs = itsdk_time_get_ms()+(uint64_t)ms;
 		return TIMER_INIT_SUCCESS;
 	}
 	#if (ITSDK_LOGGER_MODULE & __LOG_MOD_STIMER) > 0
@@ -199,7 +199,7 @@ itsdk_stimer_slot_t * itsdk_stimer_get(
  * possible. At least on every wake-up from sleep
  */
 void itsdk_stimer_run() {
-	uint32_t t = itsdk_time_get_ms();
+	uint64_t t = itsdk_time_get_ms();
 	for ( int i = 0 ; i < ITSDK_TIMER_SLOTS ; i++ ) {
 		if ( __stimer_slots[i].inUse && __stimer_slots[i].timeoutMs <= t ) {
 			__stimer_slots[i].inUse = false;
@@ -215,17 +215,18 @@ void itsdk_stimer_run() {
  * return ITSDK_STIMER_INFINITE when none are in execution or in the future.
  */
 uint32_t itsdk_stimer_nextTimeoutMs(){
-	uint32_t t = itsdk_time_get_ms();
-	uint32_t min = ITSDK_STIMER_INFINITE;
+	uint64_t t = itsdk_time_get_ms();
+	uint64_t min = ITSDK_STIMER_INFINITE_64;
 	for ( int i = 0 ; i < ITSDK_TIMER_SLOTS ; i++ ) {
 		if ( __stimer_slots[i].inUse && __stimer_slots[i].timeoutMs >= t ) {
 			if ( __stimer_slots[i].timeoutMs < min ) min = __stimer_slots[i].timeoutMs;
 		}
 	}
-	if ( min < ITSDK_STIMER_INFINITE ) {
+	if ( min < ITSDK_STIMER_INFINITE_64 ) {
 		min = min - t;
+		return min;
 	}
-	return min;
+	return ITSDK_STIMER_INFINITE;
 }
 
 #endif

--- a/Src/stm32l_sdk/rtc/rtc.c
+++ b/Src/stm32l_sdk/rtc/rtc.c
@@ -127,7 +127,7 @@ uint64_t rtc_getTimestampMsRaw(bool adjust) {
 #else
 	RTC_TimeTypeDef _time;
 	RTC_DateTypeDef _date;
-	uint32_t ms;
+	uint64_t ms;
 	HAL_RTC_GetTime(&hrtc, &_time, RTC_FORMAT_BIN);
 	HAL_RTC_GetDate(&hrtc, &_date, RTC_FORMAT_BIN);
 	ms  = (uint32_t)_time.Hours*3600*1000;
@@ -140,16 +140,16 @@ uint64_t rtc_getTimestampMsRaw(bool adjust) {
 		__rtc_days++;
 	}
 	__rtc_lastTick = ms;
-	ms = ( uint64_t )(__rtc_days*3600000L*24L)+ms;
+	ms = ( uint64_t )((uint64_t)__rtc_days*3600000L*24L)+(uint64_t)ms;
 #endif
 	// apply the RTC clock correction and add previous offset
 	#if ITSDK_WITH_CLK_ADJUST > 0
 		if (adjust && __rtc_init > 0) {
-			ms = (ms * __rtc_currentRatio) / 1000;
+			ms = (ms * (uint64_t)__rtc_currentRatio) / 1000L;
 			ms += __rtc_offset;
 		}
 	#else
-		ms = (adjust)?(ms * ITSDK_CLK_CORRECTION) / 1000:ms;
+		ms = (adjust)?(ms * ITSDK_CLK_CORRECTION) / 1000L:ms;
 	#endif
 	return ms;
 }


### PR DESCRIPTION
fix - correct the time storage in ms on 64b in RTC / Timer / Scheduler
    - basically after 90min the system was stopping to call the task manager due to a RTC time overflow due to data size and time correction having a x 1000 multiplier. Now on 64b the overflow is about 500K years ... sounds good.

evo - add example links 