### PR TITLE
Fix - when sigfox information were updated from the console, the devi…

### DIFF
--- a/Src/it_sdk/eeprom/sdk_config.c
+++ b/Src/it_sdk/eeprom/sdk_config.c
@@ -701,7 +701,10 @@ static itsdk_console_return_e _itsdk_config_consolePriv(char * buffer, uint8_t s
 				{
 					uint8_t b[4];
 					if ( __checkAndConvert(buffer,5,sz,4,b) ) {
-						bcopy(b,&itsdk_config_shadow.sdk.sigfox.deviceId,4);
+						itsdk_config_shadow.sdk.sigfox.deviceId = (b[0] << 24) & 0xFF000000;
+						itsdk_config_shadow.sdk.sigfox.deviceId |= (b[1] << 16) & 0xFF0000;
+						itsdk_config_shadow.sdk.sigfox.deviceId |= (b[2] << 8) & 0xFF00;
+						itsdk_config_shadow.sdk.sigfox.deviceId |= (b[3]) & 0xFF;
 						_itsdk_console_printf("OK\r\n");
 						return ITSDK_CONSOLE_SUCCES;
 					}

--- a/Src/it_sdk/eeprom/securestore.c
+++ b/Src/it_sdk/eeprom/securestore.c
@@ -574,6 +574,9 @@ static bool __checkAndConvert(char * str,uint8_t start,uint8_t stop,uint8_t sz,u
 
 static itsdk_console_return_e __updateField(char * buffer, uint8_t sz, uint8_t *b, itsdk_secStoreBlocks_e type) {
 	if ( __checkAndConvert(buffer,5,sz,16,b) ) {
+		if ( type == ITSDK_SS_SIGFOXKEY ) {
+		   itsdk_encrypt_cifferKey(b,16);
+		}
 		if ( itsdk_secstore_writeBlock(type, b) == SS_SUCCESS ) {
 			_itsdk_console_printf("OK\r\n");
 			return ITSDK_CONSOLE_SUCCES;


### PR DESCRIPTION
…ceID byte order was wrong and the secretkey storage was not compliant with expected format (local cipher)