### PR TITLE
Fix sleep duration interval

### DIFF
--- a/Inc/it_sdk/eeprom/sdk_state.h
+++ b/Inc/it_sdk/eeprom/sdk_state.h
@@ -28,6 +28,7 @@
 #define IT_SDK_EEPROM_SDK_STATE_H_
 
 #include <it_sdk/config.h>
+#include <it_sdk/wrappers.h>
 #include <stdint.h>
 #include <stdbool.h>
 

--- a/Src/it_sdk/eeprom/sdk_config.c
+++ b/Src/it_sdk/eeprom/sdk_config.c
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  * ----------------------------------------------------------
- * 
+ *
  *
  * ==========================================================
  */

--- a/Src/it_sdk/sched/scheduler.c
+++ b/Src/it_sdk/sched/scheduler.c
@@ -70,11 +70,11 @@ void itdt_sched_execute() {
 	for (int i = 0 ; i < __sNum ; i++) {
 		do {
 			if ( __scheds[i].nextRun <= t ) {
+	 		    __scheds[i].nextRun += (uint64_t)__scheds[i].period;
 				if ( !__scheds[i].halt ) {
 					_LOG_SCHED(("[sched] (%d) exec @%ld\r\n",i,t));
 					(*__scheds[i].func)();
 				}
-	 		    __scheds[i].nextRun += (uint64_t)__scheds[i].period;
 			}
 		} while (!__scheds[i].skip && __scheds[i].nextRun <= t );
 		while (__scheds[i].skip &&__scheds[i].nextRun <= t) __scheds[i].nextRun += __scheds[i].period;


### PR DESCRIPTION
Fix #59 and #55. Update '__scheds[i].nextRun' before running the task, it can modify it itself (unless halted). Without this patch, the real sleep duration is twice the set duration. 

