### PR TITLE
fix gauge (config, coulomb delta calculation) and secure store missing arg

### DIFF
--- a/Inc/drivers/gauge/max17205/max17205.h
+++ b/Inc/drivers/gauge/max17205/max17205.h
@@ -160,6 +160,11 @@ drivers_max17205_ret_e drivers_max17205_getRemainingNVMUpdates(uint16_t * upd);
 #define ITSDK_DRIVERS_MAX17205_REG_NHIBCFG					0x1B4
 #define ITSDK_DRIVERS_MAX17205_REG_NHIBCFG_ENHIB_MSK		0x8000	// Enable Hibernate mode switch (1) or disable it (0)
 
+#define ITSDK_DRIVERS_MAX17205_REG_NVCFG						0x1B8		// Manages NVM backup and register RAM locations
+#define ITSDK_DRIVERS_MAX17205_REG_NVCFG_DCAP_MSK			0x0010	// Enable DesignCap restore
+
+#define ITSDK_DRIVERS_MAX17205_REG_NDCAP						0x1B3		// expected capacity (non volatile)
+#define ITSDK_DRIVERS_MAX17205_REG_DCAP						0x018		// expected capacity (restored after reset)
 
 typedef enum {												//  Temp Source    RegisterToRead
 	MAX17205_REG_NPACKCFG_TEMP_INTERNAL_DIETEMP = 0x0800,	//   Internal        DieTemp (135h)

--- a/Src/drivers/gauge/max17205/max17205.c
+++ b/Src/drivers/gauge/max17205/max17205.c
@@ -96,6 +96,21 @@ static gpio_irq_chain_t __max17205_gpio_irq = {
 		NULL,
 };
 
+/**
+ * Function to detect if the passage from value A to B causes an overflow.
+ * Return 1 if overflow, 0 otherwise.
+ */
+static uint8_t __overflow_detected(uint16_t p_u16A, uint16_t p_u16B)
+{
+	uint8_t l_u8Overflow = 0u;
+
+	if (p_u16A > (UINT16_MAX - p_u16B))
+	{
+		l_u8Overflow = 1u;
+	}
+	return l_u8Overflow;
+}
+
 
 /**
  * Setup the sensor according to the selected mode.
@@ -294,6 +309,22 @@ drivers_max17205_ret_e drivers_max17205_setup(drivers_max17205_mode_e mode) {
 		break;
 
 	}
+
+	// Configure design capacity
+	// Check if DesignCap bit is enable
+   __readRegister(ITSDK_DRIVERS_MAX17205_REG_NVCFG, &v);
+   if ((v & ITSDK_DRIVERS_MAX17205_REG_NVCFG_DCAP_MSK) == 0)
+   {
+       v |= ITSDK_DRIVERS_MAX17205_REG_NVCFG_DCAP_MSK;
+       __writeRegister(ITSDK_DRIVERS_MAX17205_REG_NVCFG, v);
+   }
+   // Set design capacity value
+   // Maximum value that can be stored is 65 535 * LSB mAh
+   // LSB = 5 / ITSDK_DRIVERS_MAX17205_RSENSE_MOHM
+   v = (uint16_t) (ITSDK_DRIVERS_MAX17205_CAPA_MAX * (ITSDK_DRIVERS_MAX17205_RSENSE_MOHM/5));
+   __writeRegister(ITSDK_DRIVERS_MAX17205_REG_NDCAP, v);
+   __writeRegister(ITSDK_DRIVERS_MAX17205_REG_DCAP, v);
+
 	__max17205_config.initialized = MAX17205_SUCCESS;
 	return MAX17205_SUCCESS;
 }
@@ -405,10 +436,23 @@ drivers_max17205_ret_e drivers_max17205_getCapacity(uint16_t * mah) {
 drivers_max17205_ret_e drivers_max17205_getCoulomb(uint32_t * coulomb) {
 	uint16_t capa;
 	drivers_max17205_getCapacity(&capa);
+
+	/* High current peaks can lead to a false charge and the coulomb counter moves in the opposite direction
+	 * It is necessary to differentiate between integer overflow and reverse counting in order to process or not the measurement.
+	 * It also happens that the QH register may contain 65535 in case of an error. */
 #if ITSDK_DRIVERS_MAX17205_CSN_TO_BAT == __ENABLE
-	uint16_t delta = (capa >= __max17205_config.lastCapa )? (capa - __max17205_config.lastCapa) : (capa + (0xFFFF - __max17205_config.lastCapa));
+	if ((capa >= 0xFFFF) || ((capa < __max17205_config.lastCapa) && (__overflow_detected(__max17205_config.lastCapa,capa) == 0u)))
+	{
+		return MAX17205_FAILED;
+	}
+   uint16_t delta = (capa >= __max17205_config.lastCapa )? (capa - __max17205_config.lastCapa) : (capa + (0xFFFF - __max17205_config.lastCapa));
+
 #else
-	uint16_t delta = (capa < __max17205_config.lastCapa )? __max17205_config.lastCapa - capa : (__max17205_config.lastCapa + (0xFFFF - capa));
+	if ((capa >= 0xFFFF) || ((capa > __max17205_config.lastCapa) && (__overflow_detected(capa,__max17205_config.lastCapa) == 0u)))
+	{
+		return MAX17205_FAILED;
+	}
+	uint16_t delta = (capa <= __max17205_config.lastCapa )? __max17205_config.lastCapa - capa : (__max17205_config.lastCapa + (0xFFFF - capa));
 #endif
 	__max17205_config.totalCapa += delta;
 	__max17205_config.lastCapa = capa;

--- a/Src/it_sdk/eeprom/securestore.c
+++ b/Src/it_sdk/eeprom/securestore.c
@@ -798,7 +798,7 @@ static itsdk_console_return_e _itsdk_secStore_consolePriv(char * buffer, uint8_t
 			  case 'j':
 				  // ITSDK_SS_USER1
 				  if ( itsdk_secstore_readBlock(ITSDK_SS_USER1, b) == SS_SUCCESS ) {
-					  __console_print_hex(b,16);
+					  __console_print_hex(b,0,16);
 					  return ITSDK_CONSOLE_SUCCES;
 				  } else {
 					  _itsdk_console_printf("KO\r\n");


### PR DESCRIPTION
- config gauge capacity at setup
- fix coulomb delta calculation special use cases
- fix missing arguments in user secure store block print func